### PR TITLE
Added unit testing to Vue

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -9,7 +9,7 @@ module.exports = {
   transform: {
     '^.+\\.vue$': 'vue-jest',
     '.+\\.(css|styl|less|sass|scss|png|jpg|ttf|woff|woff2)$': 'jest-transform-stub',
-    '^.+\\.jsx?$': 'babel-jest'
+    '^.+\\.js?$': 'babel-jest'
   },
   moduleNameMapper: {
     '^@/(.*)$': '<rootDir>/src/$1'

--- a/tests/unit/BuildInformaiton.spec.js
+++ b/tests/unit/BuildInformaiton.spec.js
@@ -3,6 +3,7 @@ jest.mock('axios', () => require('./axios.mock'));
 import Vue from 'vue'
 import BuildInformation from '@/components/BuildInformation'
 import axios from 'axios'
+import { mount } from '@vue/test-utils'
 
 describe('BuildInformation.vue', () => {
 
@@ -12,24 +13,18 @@ describe('BuildInformation.vue', () => {
         expect(vm).toBeTruthy()
     });
 
-    it('should get data', () => {
+    it('test setData', () => {
         const response = {
-            data: [{
-                builds: [{
-                    state: 'passed',
-                }]
-            }]
+            builds: [
+                {state: 'passed',},
+                {state: 'passed',},
+                {state: 'failed',},
+            ]
         }
-        axios.get.mockResolvedValue(Promise.resolve(response))
-        const Constructor = Vue.extend(BuildInformation)
-        const component = new Constructor().$mount()
-        
-        //console.log(component)
-        //console.log(component.info)
+        const wrapper = mount(BuildInformation)
+        wrapper.vm.setData(response)
 
-        //expect(component.info).toBeTruthy()
-        //expect(component.passCount).toBe(1)
-        //expect(component.failCount).toBe(0)
-        //expect(component.loaded).toBe(true)
+        expect(wrapper.vm.passCount).toBe(2)
+        expect(wrapper.vm.failCount).toBe(1)
     });
 });


### PR DESCRIPTION
I added unit resting to Vue. Originally, we were trying to mock the API and use a promise, and then test that the Vue app updated with the promise. The issue with this is that the promise happens internally, and there is no built-in way to have the test wait for the promise to resolve and update the Vue, without something like timeouts.

Instead, the Vue app was made more testable by isolation the function of fetching and setting. We can now test the set function and make sure the Vue updates, without having to worry about promises at all.