### PR TITLE
Added call to GitHub API

### DIFF
--- a/config/prod.env.js
+++ b/config/prod.env.js
@@ -2,3 +2,4 @@ export const NODE_ENV = 'dev';
 export const debugMOde = true;
 export const apiURL = 'https://api.travis-ci.org';
 export const buildMasterBody = '{"request": {"branch":"master"}}';
+export const apiURLGitHub = 'https://api.github.com';

--- a/src/App.vue
+++ b/src/App.vue
@@ -20,6 +20,12 @@
                             <md-input name="api-key" id="api-key" v-model="form.apiKey" autocomplete="off" type="password" :disabled="isAuthenticated" />
                         </md-field>
                     </div>
+                    <div class="md-layout-item md-small-size-100">
+                        <md-field>
+                            <label for="api-key-github">GitHub Api Token</label>
+                            <md-input name="api-key-github" id="api-key-github" v-model="form.apiKeyGitHub" autocomplete="off" type="password" :disabled="isAuthenticated" />
+                        </md-field>
+                    </div>
                 </div>
             </md-card-content>
 
@@ -28,7 +34,7 @@
             </md-card-actions>
         </md-card>
     </form>
-    <Repositories v-if="isAuthenticated" v-bind:apiKey="form.apiKey" v-bind:organization="form.organization" />
+    <Repositories v-if="isAuthenticated" v-bind:apiKey="form.apiKey" v-bind:organization="form.organization" v-bind:apiKeyGitHub="form.apiKeyGitHub"/>
 </div>
 </template>
 
@@ -46,19 +52,20 @@ export default {
     components: {
         BuildInformation,
         Repositories,
-	BuildButton
+	    BuildButton
     },
     data: () => ({
         form: {
             apiKey: null,
             organization: null,
+            apiKeyGitHub: null
         },
         isAuthenticated: false,
         apiService: null
     }),
     methods: {
         checkForm() {
-            this.isAuthenticated = this.form.apiKey && this.form.organization;
+            this.isAuthenticated = this.form.apiKey && this.form.organization && this.form.apiKeyGitHub;
         }
     }
 }

--- a/src/components/BuildButton.vue
+++ b/src/components/BuildButton.vue
@@ -34,7 +34,7 @@ export default {
             const messageBody = `${constants.buildMasterBody}`;
             const url = `${constants.apiURL}${this.targetRepository}/${this.method}`;
             this.apiService = new TravisApiService();
-            this.apiService.post(url, messageBody, this.apiKey).then(result => {
+            GitHubApiService.post(url, messageBody, this.apiKey).then(result => {
                 this.buildId = result.request.id
             }, () => {
                 alert('An error occured');

--- a/src/components/GitHubInformation.vue
+++ b/src/components/GitHubInformation.vue
@@ -1,0 +1,69 @@
+<template>
+  <div class="display-items">
+      <md-list v-if="loaded" id="githubDump" v-for="repo in info" v-bind:key="repo.id">
+          <md-list-item>
+              <div class="md-list-item-text">
+                  <span>{{repo.name}} - {{repo.language}}</span>
+              </div>
+          </md-list-item>
+      </md-list>
+  </div>
+</template>
+
+<script>
+    import GitHubApiService from "../shared/github.api.service";
+    import * as constants from "../../config";
+
+    export default {
+        components: {
+        },
+        props: {
+            organization: String,
+            apiKeyGitHub: String,
+        },
+        data: function () {
+            return {
+                info: null,
+                error: null,
+                apiService: null,
+                method: "repos",
+                loaded: false
+            }
+        },
+        methods: {
+            async fetchData() { ///orgs/:org/repos
+                const url = `${constants.apiURLGitHub}/orgs/${this.organization}/${this.method}`;
+                this.apiService = new GitHubApiService();
+
+                const getPromise = this.apiService.get(url, this.apiKeyGitHub);
+                getPromise.then(result => {
+                    this.setData(result)
+                }, () => {
+                    this.error = 'An error occured';
+                });
+                return getPromise;
+            },
+            setData(theData) {
+                this.info = theData;
+                this.loaded = true
+            }
+        },
+        mounted() {
+            this.fetchData();
+        }
+    };
+</script>
+
+<style lang="scss" scoped>
+
+    .md-list {
+        width: 320px;
+        max-width: 100%;
+        display: inline-block;
+        vertical-align: top;
+    }
+
+    .display-items {
+        display: inline;
+    }
+</style>

--- a/src/components/Repositories.vue
+++ b/src/components/Repositories.vue
@@ -2,7 +2,10 @@
 <div>
     <md-tabs v-if="loaded">
         <md-tab v-for="repo in repositories" v-bind:key="repo.id" v-bind:id="repo.name" v-bind:md-label="repo.name">
-            <BuildInformation v-bind:targetRepository="getRepoHref(repo)" v-bind:apiKey="apiKey" />
+            <BuildInformation v-bind:targetRepository="getRepoHref(repo)" v-bind:apiKey="apiKey"/>
+        </md-tab>
+        <md-tab v-if="loaded" md-label="GitHub">
+            <GitHubInformation v-bind:apiKeyGitHub="apiKeyGitHub" v-bind:organization="organization"/>
         </md-tab>
     </md-tabs>
     <p v-if="error">{{error}}</p>
@@ -13,14 +16,17 @@
 import BuildInformation from './BuildInformation'
 import TravisApiService from '../shared';
 import * as constants from '../../config';
+import GitHubInformation from "./GitHubInformation";
 
 export default {
     components: {
+        GitHubInformation,
         BuildInformation
     },
     props: {
         apiKey: String,
         organization: String,
+        apiKeyGitHub: String,
     },
     data: function () {
         return {

--- a/src/shared/github.api.service.js
+++ b/src/shared/github.api.service.js
@@ -1,0 +1,28 @@
+import axios from "axios";
+
+export default class GitHubApiService {
+    constructor() {
+    }
+
+    get(_url, _apiKey) {
+        return axios.get(_url, {
+            responseType: 'text',
+            headers: {
+                'Content-Type': 'application/json',
+                'Accept': 'application/vnd.github.v3+json',
+                'Authorization': `token ${_apiKey}`
+            }
+        }).then(result => result.data);
+    }
+
+    post(_url, _body, _apiKey) {
+        return axios.post(_url, _body, {
+            responseType: 'text',
+            headers: {
+                'Content-Type': 'application/json',
+                'Accept': 'application/vnd.github.v3+json',
+                'Authorization': `token ${_apiKey}`
+            }
+        }).then(result => result.data);
+    }
+}

--- a/tests/unit/GitHubInformation.spec.js
+++ b/tests/unit/GitHubInformation.spec.js
@@ -1,0 +1,28 @@
+jest.mock('axios', () => require('./axios.mock'));
+
+import Vue from 'vue'
+import GitHubInformation from '@/components/GitHubInformation'
+import axios from 'axios'
+import { mount } from '@vue/test-utils'
+
+describe('GitHubInformation.vue', () => {
+
+    it('should render correct contents', () => {
+        const Constructor = Vue.extend(GitHubInformation)
+        const vm = new Constructor().$mount()
+        expect(vm).toBeTruthy()
+    });
+
+    it('test setData', () => {
+        const response =
+            [
+                {name: 'test'},
+                {name: 'test2'},
+                {name: 'test3'}
+            ];
+
+        const wrapper = mount(GitHubInformation)
+        wrapper.vm.setData(response)
+        expect(wrapper.vm.info).toEqual(response);
+    });
+});


### PR DESCRIPTION
I added another form variable and a GitHub tab. The GitHubInformation component currently just lists all the repos for the org and their language to prove it works. We can talk about what information we want to display in the future. 

I also added a unit test file with a couple of tests in it. 

[Here](https://help.github.com/articles/creating-a-personal-access-token-for-the-command-line/)  is the link to instructions to generate your own GitHub Token.