### PR TITLE
Add code coverage report

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,6 @@ yarn-error.log*
 *.njsproj
 *.sln
 *.sw*
+
+# Code coverage results
+/coverage

--- a/jest.config.js
+++ b/jest.config.js
@@ -19,5 +19,12 @@ module.exports = {
   ],
   testMatch: [
     '<rootDir>/(tests/unit/**/*.spec.(js|jsx|ts|tsx)|**/__tests__/*.(js|jsx|ts|tsx))'
-  ]
+  ],
+  "collectCoverage": true,
+  "collectCoverageFrom": [
+    "**/*.{js,vue}",
+    "!**/node_modules/**"
+  ],
+  "coverageReporters": ["html", "json", "lcov", "text"],
+  "coverageDirectory": "coverage"
 }


### PR DESCRIPTION
This branch adds a code coverage report, generated each time tests are run.

To test:

1. Checkout this branch.
2. Run ```npm run test```